### PR TITLE
Debug penjual dashboard api errors

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -24,22 +24,11 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        RateLimiter::for('api', function (Request $request) {
-        return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
-    });
-        // Panggil method untuk konfigurasi rate limiting
+        // Configure rate limiting for API routes
         $this->configureRateLimiting();
-
-        $this->routes(function () {
-            // Konfigurasi untuk route API
-            Route::middleware('api')
-                ->prefix('api')
-                ->group(base_path('routes/api.php'));
-
-            // Konfigurasi untuk route Web
-            Route::middleware('web')
-                ->group(base_path('routes/web.php'));
-        });
+        
+        // Note: In Laravel 11, routes are registered in bootstrap/app.php
+        // No need to manually register routes here
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,27 +6,26 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-    web: __DIR__.'/../routes/web.php',
-    api: __DIR__.'/../routes/api.php',
-    apiPrefix: 'api',  // ← Tambahkan ini jika belum ada
-    commands: __DIR__.'/../routes/console.php',
-    health: '/up',
+        web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
+        apiPrefix: 'api',
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-           // Exclude API routes from CSRF validation
-    $middleware->validateCsrfTokens(except: [
-        'api/*',
-    ]);
+        // Exclude API routes from CSRF validation
+        $middleware->validateCsrfTokens(except: [
+            'api/*',
+        ]);
+        
         // Register custom middleware aliases
         $middleware->alias([
             'auth' => App\Http\Middleware\Authenticate::class,
-    'penjual' => App\Http\Middleware\CheckPenjual::class,
-    'penjual.approved' => App\Http\Middleware\CheckPenjualApproved::class, // ✅ TAMBAHKAN INI
-    'mahasiswa' => App\Http\Middleware\CheckMahasiswa::class,
-    'admin' => App\Http\Middleware\CheckAdmin::class,
+            'penjual' => App\Http\Middleware\CheckPenjual::class,
+            'penjual.approved' => App\Http\Middleware\CheckPenjualApproved::class,
+            'mahasiswa' => App\Http\Middleware\CheckMahasiswa::class,
+            'admin' => App\Http\Middleware\CheckAdmin::class,
         ]);
-
-     
     })
     
     ->withExceptions(function (Exceptions $exceptions) {


### PR DESCRIPTION
Refactor Laravel 11 routing configuration to fix 404 errors on API endpoints by removing duplicate API prefix registration.

The `RouteServiceProvider` was manually registering API routes with a `prefix('api')`, which conflicted with the `apiPrefix: 'api'` configuration in `bootstrap/app.php`. This caused routes like `/api/penjual/menus` and `/api/penjual/orders` to return 404 errors. The changes ensure routing is handled solely by `bootstrap/app.php` as intended for Laravel 11.

---
<a href="https://cursor.com/background-agent?bcId=bc-434fe6bd-29e7-48ac-9e85-5ba685ef9602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-434fe6bd-29e7-48ac-9e85-5ba685ef9602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

