### PR TITLE
Debug penjual dashboard api errors

### DIFF
--- a/resources/js/components/PenjualDashboard.jsx
+++ b/resources/js/components/PenjualDashboard.jsx
@@ -121,7 +121,7 @@ const loadPenjualOrders = async () => {
   const updateOrderStatus = async (orderId, newStatus) => {
     try {
       const token = localStorage.getItem('token');
-      const response = await fetch(`${API_BASE}/orders/${orderId}/status`, {
+      const response = await fetch(`${API_BASE}/penjual/orders/${orderId}/status`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,7 @@ Route::get('/menus', [MenuController::class, 'index']);
 Route::get('/menus/{id}', [MenuController::class, 'show']);
 
 Route::get('/penjual', [PenjualController::class, 'getAllPenjual']);
-Route::get('/penjual/{id}', [PenjualController::class, 'getPenjualDetail']);
+Route::get('/penjual/{id}', [PenjualController::class, 'getPenjualDetail'])->where('id', '[0-9]+');
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
Constrain `penjual/{id}` route to numeric IDs and correct frontend order status update endpoint.

The `penjual/{id}` route was incorrectly catching `/penjual/menus` and `/penjual/orders`, leading to 404 errors for those endpoints. Additionally, the frontend was attempting to update order status using a generic `/orders/{id}/status` endpoint instead of the seller-specific `/penjual/orders/{id}/status`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef65e3b5-fb5f-46a1-a59c-ff89c4bdcc59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef65e3b5-fb5f-46a1-a59c-ff89c4bdcc59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

