### PR TITLE
Debug penjual dashboard api errors

### DIFF
--- a/resources/js/components/PenjualDashboard.jsx
+++ b/resources/js/components/PenjualDashboard.jsx
@@ -34,8 +34,7 @@ const PenjualDashboard = ({ user, API_BASE }) => {
     };
     
     testAuth();
-    
-    if (user.is_approved) {
+    if (user?.is_approved) {
       loadPenjualMenus();
       loadPenjualOrders();
     }
@@ -89,7 +88,7 @@ const loadPenjualOrders = async () => {
     const token = localStorage.getItem('token');
     console.log('Loading penjual orders...');
     
-    const response = await fetch(`${API_BASE}/penjual/orders`, { // HAPUS /api/
+    const response = await fetch(`${API_BASE}/penjual/orders`, {
       headers: { 
         'Authorization': `Bearer ${token}`,
         'Accept': 'application/json'
@@ -121,7 +120,7 @@ const loadPenjualOrders = async () => {
   const updateOrderStatus = async (orderId, newStatus) => {
     try {
       const token = localStorage.getItem('token');
-      const response = await fetch(`${API_BASE}/orders/${orderId}/status`, {
+      const response = await fetch(`${API_BASE}/penjual/orders/${orderId}/status`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,7 @@ Route::get('/menus', [MenuController::class, 'index']);
 Route::get('/menus/{id}', [MenuController::class, 'show']);
 
 Route::get('/penjual', [PenjualController::class, 'getAllPenjual']);
-Route::get('/penjual/{id}', [PenjualController::class, 'getPenjualDetail']);
+Route::get('/penjual/{id}', [PenjualController::class, 'getPenjualDetail'])->whereNumber('id');
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
Fix 404 errors for order status updates and improve data loading robustness in `PenjualDashboard`.

The frontend was calling an incorrect API endpoint (`/orders/:id/status` instead of `/penjual/orders/:id/status`) for updating order statuses, which resulted in 404 errors. This PR corrects the endpoint call and adds a nullish coalescing operator to `user?.is_approved` to prevent issues when the `user` object is not yet fully hydrated. A route constraint was also added to the `/penjual/{id}` endpoint in `api.php`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf3631ca-d2a7-4cbd-8f4f-ce7b6937ee2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf3631ca-d2a7-4cbd-8f4f-ce7b6937ee2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

